### PR TITLE
Attach and Detach databases when joining tables across databases

### DIFF
--- a/src/main/java/com/sarality/datasource/JoinQueryDataSource.java
+++ b/src/main/java/com/sarality/datasource/JoinQueryDataSource.java
@@ -1,11 +1,15 @@
 package com.sarality.datasource;
 
+import android.content.Context;
+
 import com.sarality.db.SQLiteTable;
 import com.sarality.db.TableRegistry;
 import com.sarality.db.cursor.JoinQueryCursorDataExtractor;
 import com.sarality.db.query.SimpleJoinQueryBuilder;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Reads data from a Table using a custom Data Extractor for a Raw Query
@@ -15,6 +19,7 @@ import java.util.List;
 public class JoinQueryDataSource<T> implements DataSource<List<T>> {
 
   // TODO(abhideep): User table rather than SQLite inheritance
+  private final Context context;
   private final SQLiteTable<T> table;
   private final SimpleJoinQueryBuilder queryBuilder;
   private final JoinQueryCursorDataExtractor<T> cursorDataExtractor;
@@ -23,6 +28,12 @@ public class JoinQueryDataSource<T> implements DataSource<List<T>> {
 
   public JoinQueryDataSource(TableRegistry registry, String tableName, SimpleJoinQueryBuilder queryBuilder,
       JoinQueryCursorDataExtractor<T> cursorDataExtractor) {
+    this(null, registry, tableName, queryBuilder, cursorDataExtractor);
+  }
+
+  public JoinQueryDataSource(Context context, TableRegistry registry, String tableName,
+      SimpleJoinQueryBuilder queryBuilder, JoinQueryCursorDataExtractor<T> cursorDataExtractor) {
+    this.context = context;
     this.table = (SQLiteTable<T>) registry.getTable(tableName);
     this.queryBuilder = queryBuilder;
     this.cursorDataExtractor = cursorDataExtractor;
@@ -32,10 +43,45 @@ public class JoinQueryDataSource<T> implements DataSource<List<T>> {
   public List<T> load() {
     try {
       table.open();
+      if (context != null) {
+        attachDatabases();
+      }
       dataList = table.readAll(queryBuilder.build(), cursorDataExtractor);
       return dataList;
     } finally {
+      if (context != null) {
+        detachDatabases();
+      }
       table.close();
+    }
+  }
+
+  private void attachDatabases() {
+    Set<String> dbNameSet = new HashSet<>();
+    List<String> dbNameList = queryBuilder.getDatabaseList();
+    if (dbNameList != null && !dbNameList.isEmpty()) {
+      for (String dbName : dbNameList) {
+        if (!dbNameSet.contains(dbName)) {
+          String sql = "ATTACH DATABASE ? AS " + queryBuilder.getDatabaseAlias(dbName);
+          String[] queryArgs = new String[] {context.getDatabasePath(dbName).getPath()};
+          table.execSQL(sql, queryArgs);
+          dbNameSet.add(dbName);
+        }
+      }
+    }
+  }
+
+  private void detachDatabases() {
+    Set<String> dbNameSet = new HashSet<>();
+    List<String> dbNameList = queryBuilder.getDatabaseList();
+    if (dbNameList != null && !dbNameList.isEmpty()) {
+      for (String dbName : dbNameList) {
+        if (!dbNameSet.contains(dbName)) {
+          String sql = "DETACH DATABASE " + queryBuilder.getDatabaseAlias(dbName);
+          table.execSQL(sql, null);
+          dbNameSet.add(dbName);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Passing in a content is the datasource and db name in Join Query
enables the call to attach and detach databases.